### PR TITLE
Define new syntax regions for advanced highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,98 @@ For example, you can install this plugin with [neobundle.vim](https://github.com
 NeoBundle 'rhysd/conflict-marker.vim'
 ```
 
+## Conflict Markers
+
+Conflict markers can be customized using the following options:
+
+```vim
+" Default values
+let g:conflict_marker_begin = '^<<<<<<< \@='
+let g:conflict_marker_separator = '^=======$'
+let g:conflict_marker_end   = '^>>>>>>> \@='
+```
+
 ## Highlight Conflict Markers
 
-Conflict markers (`<<<<<<<`, `=======` and `>>>>>>>` as default) are highlighted automatically.
+Conflict markers are highlighted by default. Use the following option to disable
+highlighting:
+
+```vim
+let g:conflict_marker_enable_highlight = 0
+```
+
+Each conflict marker and conflict part is associated to a specific syntax group:
+
+| marker / part | syntax group |
+|------|--------------|
+| begin conflict marker (`<<<<<<<`) | `ConflictMarkerBegin` |
+| *ours* part of the conflict | `ConflictMarkerOurs` |
+| separator conflict marker (`=======`) | `ConflictMarkerSeparator` |
+| *theirs* part of the conflict | `ConflictMarkerTheirs` |
+| end conflict marker (`>>>>>>>`) | `ConflictMarkerEnd` |
+
+By default, `ConflictMarkerBegin`, `ConflictMarkerSeparator` and
+`ConflictMarkerEnd` are linked to the `Error` syntax group. To link them to
+another syntax group, use the following option:
+
+```vim
+" Default value
+let g:conflict_marker_highlight_group = 'Error'
+```
+
+`ConflictMarkerOurs` and `ConflictMarkerTheirs` are not linked to any syntax
+group by default, and can be used to customize the highlight of the *ours* and *theirs*
+parts of the conflict.
+
+To use a specific highlight for each marker, disable the default highlight
+group, and define your own highlights for each syntax group.
+
+**Example:**
+
+```vim
+" disable the default highlight group
+let g:conflict_marker_highlight_group = ''
+
+" Include text after begin and end markers
+let g:conflict_marker_begin = '^<<<<<<< .*$'
+let g:conflict_marker_end   = '^>>>>>>> .*$'
+
+highlight ConflictMarkerBegin guibg=#2f7366
+highlight ConflictMarkerOurs guibg=#2e5049
+highlight ConflictMarkerTheirs guibg=#344f69
+highlight ConflictMarkerEnd guibg=#2f628e
+```
+
+![Screenshot_20190911_212653](https://user-images.githubusercontent.com/454315/64728297-f8953d80-d4da-11e9-9033-df5bfdee2f7a.png)
 
 ## Jump among Conflict Markers
 
-`[x` and `]x` mappings are defined as default.
+`[x` and `]x` mappings are defined as default. Use the following option to
+disable them:
+
+```vim
+let g:conflict_marker_enable_mappings = 0
+```
 
 ## Jump within a Conflict Marker
 
 This feature uses matchit.vim, which is bundled in Vim (`macros/matchit.vim`).
-`%` mapping is extened by matchit.vim.
+`%` mapping is extended by matchit.vim. Use the following option to disable this
+feature:
+
+```vim
+let g:conflict_marker_enable_matchit = 0
+```
 
 ## Resolve a Conflict with Various Strategies
 
-This plugin defines mappings as default, `ct` for themselves, `co` for ourselves, `cn` for none and `cb` for both.
+This plugin defines mappings as default: `ct` for themselves, `co` for
+ourselves, `cn` for none and `cb` for both.  Use the following option to disable
+mappings:
+
+```vim
+let g:conflict_marker_enable_mappings = 0
+```
 
 ### Themselves
 
@@ -59,7 +135,7 @@ themselves
 >>>>>>> deadbeef0123
 ```
 
-↓`ct` or `ConflictMarkerThemselves`
+↓`ct` or `:ConflictMarkerThemselves`
 
 ```
 themselves

--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -72,17 +72,34 @@ function! s:set_conflict_marker_to_match_words()
     let b:conflict_marker_match_words_loaded = 1
 endfunction
 
+function! s:create_highlight_links()
+    if exists('g:conflict_marker_highlight_group') && strlen(g:conflict_marker_highlight_group)
+        execute 'highlight link ConflictMarkerBegin '.g:conflict_marker_highlight_group
+        execute 'highlight link ConflictMarkerSeparator '.g:conflict_marker_highlight_group
+        execute 'highlight link ConflictMarkerEnd '.g:conflict_marker_highlight_group
+    endif
+endfunction
+
 function! s:on_detected()
     if g:conflict_marker_enable_hooks
         call s:execute_hooks()
     endif
 
     if g:conflict_marker_enable_highlight
-        execute printf('syntax match ConflictMarker containedin=ALL /\%(%s\|%s\|%s\)/',
+        execute printf('syntax match ConflictMarkerBegin containedin=ALL /%s/',
+                \      g:conflict_marker_begin)
+        execute printf('syntax region ConflictMarkerOurs containedin=ALL start=/%s/hs=e+1 end=/%s\&/',
                 \      g:conflict_marker_begin,
+                \      g:conflict_marker_separator)
+        execute printf('syntax match ConflictMarkerSeparator containedin=ALL /%s/',
+                \      g:conflict_marker_separator)
+        execute printf('syntax region ConflictMarkerTheirs containedin=ALL start=/%s/hs=e+1 end=/%s\&/',
                 \      g:conflict_marker_separator,
                 \      g:conflict_marker_end)
-        execute 'highlight link ConflictMarker '.g:conflict_marker_highlight_group
+        execute printf('syntax match ConflictMarkerEnd containedin=ALL /%s/',
+                \      g:conflict_marker_end)
+
+        call s:create_highlight_links()
     endif
 
     if g:conflict_marker_enable_matchit
@@ -96,7 +113,7 @@ augroup ConflictMarkerDetect
 augroup END
 
 if g:conflict_marker_enable_highlight
-    execute 'highlight link ConflictMarker '.g:conflict_marker_highlight_group
+    call s:create_highlight_links()
 endif
 
 let &cpo = s:save_cpo

--- a/t/syntax_spec.vim
+++ b/t/syntax_spec.vim
@@ -46,14 +46,22 @@ describe 'Conflict marker'
 
     it 'is highlighted'
         doautocmd BufReadPost
-        for l in [1, 3, 5, 8, 10, 12, 15, 17, 19]
-            Expect GetHighlight(l, 1) ==# 'ConflictMarker'
+        for l in [1, 8, 15]
+            Expect GetHighlight(l, 1) ==# 'ConflictMarkerBegin'
+            Expect GetHighlight(l+1, 2) ==# 'ConflictMarkerOurs'
+            Expect GetHighlight(l+2, 3) ==# 'ConflictMarkerSeparator'
+            Expect GetHighlight(l+3, 4) ==# 'ConflictMarkerTheirs'
+            Expect GetHighlight(l+4, 5) ==# 'ConflictMarkerEnd'
         endfor
     end
 
     it 'is not highlighted if no marker is detected at BufReadPost'
-        for l in [1, 3, 5, 8, 10, 12, 15, 17, 19]
-            Expect GetHighlight(l, 1) !=# 'ConflictMarker'
+        for l in [1, 8, 15]
+            Expect GetHighlight(l, 1) !=# 'ConflictMarkerBegin'
+            Expect GetHighlight(l+1, 2) !=# 'ConflictMarkerOurs'
+            Expect GetHighlight(l+2, 3) !=# 'ConflictMarkerSeparator'
+            Expect GetHighlight(l+3, 4) !=# 'ConflictMarkerTheirs'
+            Expect GetHighlight(l+4, 5) !=# 'ConflictMarkerEnd'
         endfor
     end
 end


### PR DESCRIPTION
This PR offers to define additional syntax regions allowing to further customize the highlighting of the different parts of a conflict.

New syntax regions are:
- **ConflictMarkerBegin:** allows to use a specific highlighting for the begin marker of a conflict (`<<<<<<<`)
- **ConflictMarkerOurs:** allows to use a specific highlighting for the part between the begin marker and the separator marker
- **ConflictMarkerSeparator:** allows to use a specific highlight for the separator marker of a conflict (`=======`)
- **ConflictMarkerTheirs:** allows to use a specific highlighting for the part between the separator marker and the end marker
- **ConflictMarkerEnd:** allows to use a specific highlight for the end marker of a conflict (`>>>>>>>`)

By default the highlight of the **ConflictMarkerBegin**, **ConflictMarkerSeparator** and **ConflictMarkerEnd** regions are a link to the group defined by `g:conflict_marker_highlight_group` to be compatible with the existing highlighting behavior.

To customize the highlighting of the different parts of a conflict, set `g:conflict_marker_highlight_group` to `''` and define the highlighting of the desired parts.

**Example**

```vim
" disable default highlight links to g:conflict_marker_highlight_group
let g:conflict_marker_highlight_group = ''

" Include text after begin and end markers
let g:conflict_marker_begin = '^<<<<<<< .*$'
let g:conflict_marker_end   = '^>>>>>>> .*$'

highlight ConflictMarkerBegin guibg=#2f7366
highlight ConflictMarkerOurs guibg=#2e5049
highlight ConflictMarkerTheirs guibg=#344f69
highlight ConflictMarkerEnd guibg=#2f628e
```

**Result**

![Screenshot_20190911_212653](https://user-images.githubusercontent.com/454315/64728297-f8953d80-d4da-11e9-9033-df5bfdee2f7a.png)