### PR TITLE
.gitignore tags files, and run CI on trusty rather than xenial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vim-flavor
 .*.sw?
 .sw?
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 rvm:
   - 1.9.3


### PR DESCRIPTION
When I run `:helptags`, it creates doc/tags, and that file dirties the repo.  This just adds tags to the .gitignore.  Thanks for this tool, and for considering this PR!

**Edit** Also changes the Travis to trusty to fix CI failures.