### PR TITLE
match conflict markers more liberally

### DIFF
--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -10,9 +10,9 @@ function! s:var(name, default)
 endfunction
 
 call s:var('highlight_group', 'Error')
-call s:var('begin', '^<<<<<<< \@=')
+call s:var('begin', '^<<<<<<<')
 call s:var('separator', '^=======$')
-call s:var('end', '^>>>>>>> \@=')
+call s:var('end', '^>>>>>>>')
 call s:var('enable_mappings', 1)
 call s:var('enable_hooks', 1)
 call s:var('enable_highlight', 1)


### PR DESCRIPTION
The `patch` utility from <https://github.com/twaugh/patchutils> only writes the markers when applying conflicting patches with `--merge`, without any more text after them. Relax the `begin` and `end` patterns accordingly — seven of those special chars should still be enough to not match anything unwanted.