### PR TITLE
Add more autocommands to refresh highlighting

### DIFF
--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -109,7 +109,7 @@ endfunction
 
 augroup ConflictMarkerDetect
     autocmd!
-    autocmd BufReadPost * if conflict_marker#detect#markers() | call s:on_detected() | endif
+    autocmd BufEnter,FocusGained,ColorScheme * if conflict_marker#detect#markers() | call s:on_detected() | endif
 augroup END
 
 if g:conflict_marker_enable_highlight

--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -109,7 +109,9 @@ endfunction
 
 augroup ConflictMarkerDetect
     autocmd!
-    autocmd BufEnter,FocusGained,ColorScheme * if conflict_marker#detect#markers() | call s:on_detected() | endif
+    autocmd BufReadPost,BufEnter,FocusGained,ColorScheme * if conflict_marker#detect#markers()
+                \ | call s:on_detected()
+                \ | endif
 augroup END
 
 if g:conflict_marker_enable_highlight

--- a/t/default_spec.vim
+++ b/t/default_spec.vim
@@ -10,9 +10,9 @@ describe 'Default settings'
     it 'provide variables to customize'
         Expect 'g:loaded_conflict_marker' to_exist
         Expect 'g:conflict_marker_highlight_group' to_exist_and_default_to 'Error'
-        Expect 'g:conflict_marker_begin' to_exist_and_default_to '^<<<<<<< \@='
+        Expect 'g:conflict_marker_begin' to_exist_and_default_to '^<<<<<<<'
         Expect 'g:conflict_marker_separator' to_exist_and_default_to '^=======$'
-        Expect 'g:conflict_marker_end' to_exist_and_default_to '^>>>>>>> \@='
+        Expect 'g:conflict_marker_end' to_exist_and_default_to '^>>>>>>>'
         Expect 'g:conflict_marker_enable_mappings' to_exist_and_default_to 1
         Expect 'g:conflict_marker_enable_hooks' to_exist_and_default_to 1
         Expect 'g:conflict_marker_enable_highlight' to_exist_and_default_to 1

--- a/t/default_spec.vim
+++ b/t/default_spec.vim
@@ -50,7 +50,7 @@ describe 'Default settings'
         for l in range(1, len(lines))
             call setline(l, lines[l-1])
         endfor
-        doautocmd BufReadPost
+        doautocmd BufEnter
 
         Expect ']x' to_map_in 'n'
         Expect '[x' to_map_in 'n'

--- a/t/hooks_spec.vim
+++ b/t/hooks_spec.vim
@@ -28,7 +28,7 @@ describe 'g:conflict_marker_hooks'
 
     it 'does nothing if does not have on_detected hook'
         let g:conflict_marker_hooks = {}
-        Expect 'doautocmd BufReadPost' not to_throw_exception
+        Expect 'doautocmd BufEnter' not to_throw_exception
     end
 
     it 'execute on_detected hook specified by string'
@@ -38,7 +38,7 @@ describe 'g:conflict_marker_hooks'
         endfunction
         let g:conflict_marker_hooks = {'on_detected' : 'TestHook'}
 
-        doautocmd BufReadPost
+        doautocmd BufEnter
         Expect g:test_hooked to_be_true
         unlet g:test_hooked
     end
@@ -50,7 +50,7 @@ describe 'g:conflict_marker_hooks'
             let g:test_hooked = 1
         endfunction
 
-        doautocmd BufReadPost
+        doautocmd BufEnter
         Expect g:test_hooked to_be_true
         unlet g:test_hooked
     end

--- a/t/matchit_spec.vim
+++ b/t/matchit_spec.vim
@@ -28,7 +28,7 @@ describe 'matchit'
 
     it 'defines b:match_words'
         Expect 'b:match_words' to_exist
-        Expect b:match_words =~# '\V,^<<<<<<< \\@=:^=======$:^>>>>>>> \\@='
+        Expect b:match_words =~# ',^<<<<<<<:^=======$:^>>>>>>>'
     end
 
     it 'can jump within a conflict marker'

--- a/t/matchit_spec.vim
+++ b/t/matchit_spec.vim
@@ -19,7 +19,7 @@ describe 'matchit'
         for l in range(1, len(s:lines))
             call setline(l, s:lines[l-1])
         endfor
-        doautocmd BufRead
+        doautocmd BufEnter
     end
 
     after

--- a/t/resolve_spec.vim
+++ b/t/resolve_spec.vim
@@ -24,7 +24,7 @@ describe ':ConflictMarkerThemselves'
     before
         new
         call s:load()
-        doautocmd BufRead
+        doautocmd BufEnter
     end
 
     after
@@ -47,7 +47,7 @@ describe ':ConflictMarkerOurselves'
     before
         new
         call s:load()
-        doautocmd BufRead
+        doautocmd BufEnter
     end
 
     after
@@ -70,7 +70,7 @@ describe ':ConflictMarkerNone'
     before
         new
         call s:load()
-        doautocmd BufRead
+        doautocmd BufEnter
     end
 
     after
@@ -93,7 +93,7 @@ describe ':ConflictMarkerBoth'
     before
         new
         call s:load()
-        doautocmd BufRead
+        doautocmd BufEnter
     end
 
     after

--- a/t/syntax_spec.vim
+++ b/t/syntax_spec.vim
@@ -45,7 +45,7 @@ describe 'Conflict marker'
     end
 
     it 'is highlighted'
-        doautocmd BufReadPost
+        doautocmd BufEnter
         for l in [1, 8, 15]
             Expect GetHighlight(l, 1) ==# 'ConflictMarkerBegin'
             Expect GetHighlight(l+1, 2) ==# 'ConflictMarkerOurs'
@@ -55,7 +55,7 @@ describe 'Conflict marker'
         endfor
     end
 
-    it 'is not highlighted if no marker is detected at BufReadPost'
+    it 'is not highlighted if no marker is detected at BufEnter'
         for l in [1, 8, 15]
             Expect GetHighlight(l, 1) !=# 'ConflictMarkerBegin'
             Expect GetHighlight(l+1, 2) !=# 'ConflictMarkerOurs'


### PR DESCRIPTION
Hi 👋🏿 thanks for the great plugin. I've created this PR to fix a few issues I've been having using this plugin. This PR adds/changes the autocommands this plugin uses to check if there are conflicts and apply highlights and mappings.

## Problem
- [x] If you source your `init.vim` then go to a file with a conflict, highlights are absent.
- [x] If you change your colorscheme highlights disappear.
- [x] Using `BufReadPost` only applies the first time a file is read e.g. you are editing `file1.txt`, you move to another buffer and perform a git merge, a conflict occurs and you go back to `file1.txt`. It will not pick up the highlights as the buffer has already had a `BufReadPost`

### Abandoned
* If you have an already opened buffer then do a merge an (external) terminal then navigate back there is no highlight.

## Solution
Use `BufEnter,ColorScheme` autocommands to re-apply syntax groups so highlighting is preserved, `BufEnter` also happens quite reliably so is a good point to check if a merge happened at some point.

I couldn't find a good autocommand to fix the last issue. If you have `checktime` being called in a `FocusGained` autocommand this will update the buffer but still `BufEnter` and `FocusGained` think the order of events prevents this being picked up somehow.