### PR TITLE
Add flag to toggle detection at runtime

### DIFF
--- a/autoload/conflict_marker/detect.vim
+++ b/autoload/conflict_marker/detect.vim
@@ -2,6 +2,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! conflict_marker#detect#markers() abort
+  if g:conflict_marker_enable_detect
     let pos_save = getpos('.')
     try
         keepjumps call cursor(1, 1)
@@ -15,6 +16,7 @@ function! conflict_marker#detect#markers() abort
     finally
         call setpos('.', pos_save)
     endtry
+  endif
 endfunction
 
 let &cpo = s:save_cpo

--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -18,6 +18,7 @@ call s:var('enable_mappings', 1)
 call s:var('enable_hooks', 1)
 call s:var('enable_highlight', 1)
 call s:var('enable_matchit', 1)
+call s:var('enable_detect', 1)
 
 command! -nargs=0 ConflictMarkerThemselves     call conflict_marker#themselves()
 command! -nargs=0 ConflictMarkerOurselves      call conflict_marker#ourselves()


### PR DESCRIPTION
This makes it possible to enable or disable detection during an autocmd event, which is useful as detection can be slow on extremely large files.