### PR TITLE
add more autocommand events to re-detect markers

### DIFF
--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -119,7 +119,7 @@ endfunction
 
 augroup ConflictMarkerDetect
     autocmd!
-    autocmd BufReadPost,BufEnter,FocusGained,ColorScheme * if conflict_marker#detect#markers()
+    autocmd BufReadPost,FileChangedShellPost,ShellFilterPost,StdinReadPost,BufEnter,FocusGained,ColorScheme * if conflict_marker#detect#markers()
                 \ | call s:on_detected()
                 \ | endif
 augroup END


### PR DESCRIPTION
Run the marker detection autocommand in the following cases that could add conflict markers to the buffer:

* when vim detects that the file in the current buffer has been changed externally (e.g. when executing a `patch --merge < my.patch` that patches the current file)

* when reading into the current buffer from stdin with `:read`

* when filtering the current buffer through a shell command with `:!%`