### PR TITLE
Doc updates and change default g:conflict_marker_common_ancestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Conflict markers can be customized using the following options:
 ```vim
 " Default values
 let g:conflict_marker_begin = '^<<<<<<< \@='
-let g:conflict_marker_common_ancestors = '^||||||| .*$'
+let g:conflict_marker_common_ancestors = '^|||||||'
 let g:conflict_marker_separator = '^=======$'
 let g:conflict_marker_end   = '^>>>>>>> \@='
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Conflict markers can be customized using the following options:
 ```vim
 " Default values
 let g:conflict_marker_begin = '^<<<<<<< \@='
-let g:conflict_marker_common_ancestors = '^|||||||'
+let g:conflict_marker_common_ancestors = '^|||||||\+'
 let g:conflict_marker_separator = '^=======$'
 let g:conflict_marker_end   = '^>>>>>>> \@='
 ```

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ group, and define your own highlights for each syntax group.
 " disable the default highlight group
 let g:conflict_marker_highlight_group = ''
 
-" Include text after begin and end markers
+" Include text after begin, common ancestors and end markers
 let g:conflict_marker_begin = '^<<<<<<< .*$'
+let g:conflict_marker_common_ancestors = '^|||||||\+ .*$'
 let g:conflict_marker_end   = '^>>>>>>> .*$'
 
 highlight ConflictMarkerBegin guibg=#2f7366

--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -11,7 +11,7 @@ endfunction
 
 call s:var('highlight_group', 'Error')
 call s:var('begin', '^<<<<<<<')
-call s:var('common_ancestors', '^|||||||')
+call s:var('common_ancestors', '^|||||||\+')
 call s:var('separator', '^=======$')
 call s:var('end', '^>>>>>>>')
 call s:var('enable_mappings', 1)

--- a/test/test_default.vimspec
+++ b/test/test_default.vimspec
@@ -3,7 +3,7 @@ Describe Default settings
         Assert Exists('g:loaded_conflict_marker')
         Assert Equals(g:conflict_marker_highlight_group, 'Error')
         Assert Equals(g:conflict_marker_begin, '^<<<<<<<')
-        Assert Equals(g:conflict_marker_common_ancestors, '^|||||||')
+        Assert Equals(g:conflict_marker_common_ancestors, '^|||||||\+')
         Assert Equals(g:conflict_marker_separator, '^=======$')
         Assert Equals(g:conflict_marker_end, '^>>>>>>>')
         Assert Equals(g:conflict_marker_enable_mappings, 1)

--- a/test/test_matchit.vimspec
+++ b/test/test_matchit.vimspec
@@ -35,7 +35,7 @@ Describe matchit
 
     It defines b:match_words
         Assert Exists('b:match_words')
-        Assert Match(b:match_words, ',^<<<<<<<:^|||||||:^=======$:^>>>>>>>')
+        Assert Match(b:match_words, ',^<<<<<<<:^|||||||\\+:^=======$:^>>>>>>>')
     End
 
     It can jump within a conflict marker


### PR DESCRIPTION
- Fix default g:conflict_marker_common_ancestors
- Match 7 or more pipes as common ancestors marker

    I'm not that sure about this commit. From [1]'s commit message, it
    seems that there can be more than 7 pipes when conflict is 'nested'.
    However I've never seen such a case and I wasn't able to find an
    example online.

    But if my assumption is correct, I guess it makes more sense to
    match 7 _or more_ pipes to avoid partial highlight?
- Add full line common ancestors example

    Since the goal of the example configuration here seems to be making
    highlight of each whole marker line consistent, it'd be nice to
    configure g:conflict_marker_common_ancestors as well to prevent
    ancestor commit hashes from being highlighted differently.

    Before: ![image](https://user-images.githubusercontent.com/4507647/154492789-fb3421c4-b81c-4846-a989-344f404a5ab7.png)

    After: ![image](https://user-images.githubusercontent.com/4507647/154492874-b0f04f6d-4b32-40a0-9a0a-1d026ba288bf.png)


[1] https://github.com/rhysd/conflict-marker.vim/commit/0ada2b9e09d91bf15647a223180f89a1a33a762f
