### PR TITLE
add :ConflictMarkerCommonAncestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ theirs
 ```
 ```
 
+### Apply Common Ancestor's
+
+```
+<<<<<<< HEAD
+ours
+||||||| 11a4d4224475
+ancestor
+=======
+theirs
+>>>>>>> deadbeef0123
+```
+
+↓`ca` or `:ConflictMarkerCommonAncestors`
+
+```
+ancestor
+```
+
 ## Customize
 
 TODO

--- a/autoload/conflict_marker.vim
+++ b/autoload/conflict_marker.vim
@@ -124,6 +124,18 @@ function! conflict_marker#compromise(reverse) abort
     silent! call repeat#set("\<Plug>(conflict-marker-both)", v:count)
 endfunction
 
+" Note: temporary implementation, linewise
+function! conflict_marker#common_ancestors() abort
+    let markers = conflict_marker#markers()
+    if ! s:valid_hunk(markers) | return | endif
+    let common_ancestors_pos = s:current_conflict_common_ancestors(markers[0], markers[1])
+    if common_ancestors_pos == [0, 0] | return | endif
+    " :silent to prevent hit-enter prompt
+    execute 'silent' markers[1][0] . ',' . markers[2][0] . 'delete' '_'
+    execute 'silent' markers[0][0] . ',' . common_ancestors_pos[0] . 'delete' '_'
+    silent! call repeat#set("\<Plug>(conflict-marker-common-ancestors)", v:count)
+endfunction
+
 function! s:jump_to_hunk_if_valid(original_pos, hunk) abort
     if s:valid_hunk(a:hunk)
         call cursor(a:hunk[0][0], a:hunk[0][1])

--- a/doc/conflict-marker.txt
+++ b/doc/conflict-marker.txt
@@ -22,8 +22,8 @@ conflict-marker.vim does
 1. highlight conflict markers.
 2. jump among conflict markers.
 3. jump within conflict block; begin, separator and end of the block.
-4. resolve conflict with various strategies; "theirs", "ours", "none"
-   and "both".
+4. resolve conflict with various strategies; "theirs", "ours", "none",
+   "both", and "common ancestor's"
 
 ==============================================================================
 USAGE                                                *conflict-marker.vim-usage*

--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -20,20 +20,22 @@ call s:var('enable_highlight', 1)
 call s:var('enable_matchit', 1)
 call s:var('enable_detect', 1)
 
-command! -nargs=0 ConflictMarkerThemselves     call conflict_marker#themselves()
-command! -nargs=0 ConflictMarkerOurselves      call conflict_marker#ourselves()
-command! -nargs=0 -bang ConflictMarkerBoth     call conflict_marker#compromise(<bang>0)
-command! -nargs=0 ConflictMarkerNone           call conflict_marker#down_together()
-command! -nargs=0 -bang ConflictMarkerNextHunk call conflict_marker#next_conflict(<bang>0)
-command! -nargs=0 -bang ConflictMarkerPrevHunk call conflict_marker#previous_conflict(<bang>0)
+command! -nargs=0 ConflictMarkerThemselves      call conflict_marker#themselves()
+command! -nargs=0 ConflictMarkerOurselves       call conflict_marker#ourselves()
+command! -nargs=0 -bang ConflictMarkerBoth      call conflict_marker#compromise(<bang>0)
+command! -nargs=0 ConflictMarkerNone            call conflict_marker#down_together()
+command! -nargs=0 ConflictMarkerCommonAncestors call conflict_marker#common_ancestors()
+command! -nargs=0 -bang ConflictMarkerNextHunk  call conflict_marker#next_conflict(<bang>0)
+command! -nargs=0 -bang ConflictMarkerPrevHunk  call conflict_marker#previous_conflict(<bang>0)
 
-nnoremap <silent><Plug>(conflict-marker-themselves) :<C-u>ConflictMarkerThemselves<CR>
-nnoremap <silent><Plug>(conflict-marker-ourselves)  :<C-u>ConflictMarkerOurselves<CR>
-nnoremap <silent><Plug>(conflict-marker-both)       :<C-u>ConflictMarkerBoth<CR>
-nnoremap <silent><Plug>(conflict-marker-both-rev)   :<C-u>ConflictMarkerBoth!<CR>
-nnoremap <silent><Plug>(conflict-marker-none)       :<C-u>ConflictMarkerNone<CR>
-nnoremap <silent><Plug>(conflict-marker-next-hunk)  :<C-u>ConflictMarkerNextHunk<CR>
-nnoremap <silent><Plug>(conflict-marker-prev-hunk)  :<C-u>ConflictMarkerPrevHunk<CR>
+nnoremap <silent><Plug>(conflict-marker-themselves)       :<C-u>ConflictMarkerThemselves<CR>
+nnoremap <silent><Plug>(conflict-marker-ourselves)        :<C-u>ConflictMarkerOurselves<CR>
+nnoremap <silent><Plug>(conflict-marker-both)             :<C-u>ConflictMarkerBoth<CR>
+nnoremap <silent><Plug>(conflict-marker-both-rev)         :<C-u>ConflictMarkerBoth!<CR>
+nnoremap <silent><Plug>(conflict-marker-none)             :<C-u>ConflictMarkerNone<CR>
+nnoremap <silent><Plug>(conflict-marker-common-ancestors) :<C-u>ConflictMarkerCommonAncestors<CR>
+nnoremap <silent><Plug>(conflict-marker-next-hunk)        :<C-u>ConflictMarkerNextHunk<CR>
+nnoremap <silent><Plug>(conflict-marker-prev-hunk)        :<C-u>ConflictMarkerPrevHunk<CR>
 
 function! s:execute_hooks()
     if g:conflict_marker_enable_mappings
@@ -44,6 +46,7 @@ function! s:execute_hooks()
         nmap <buffer>cn <Plug>(conflict-marker-none)
         nmap <buffer>cb <Plug>(conflict-marker-both)
         nmap <buffer>cB <Plug>(conflict-marker-both-rev)
+        nmap <buffer>ca <Plug>(conflict-marker-common-ancestors)
     endif
 
     if exists('g:conflict_marker_hooks') && has_key(g:conflict_marker_hooks, 'on_detected')

--- a/test/test_default.vimspec
+++ b/test/test_default.vimspec
@@ -17,6 +17,7 @@ Describe Default settings
         Assert Exists(':ConflictMarkerOurselves')
         Assert Exists(':ConflictMarkerBoth')
         Assert Exists(':ConflictMarkerNone')
+        Assert Exists(':ConflictMarkerCommonAncestors')
         Assert Exists(':ConflictMarkerNextHunk')
         Assert Exists(':ConflictMarkerPrevHunk')
     End
@@ -27,6 +28,7 @@ Describe Default settings
         Assert NotEmpty(mapcheck('<Plug>(conflict-marker-both)', 'n'))
         Assert NotEmpty(mapcheck('<Plug>(conflict-marker-both-rev)', 'n'))
         Assert NotEmpty(mapcheck('<Plug>(conflict-marker-none)', 'n'))
+        Assert NotEmpty(mapcheck('<Plug>(conflict-marker-common-ancestors)', 'n'))
         Assert NotEmpty(mapcheck('<Plug>(conflict-marker-next-hunk)', 'n'))
         Assert NotEmpty(mapcheck('<Plug>(conflict-marker-prev-hunk)', 'n'))
     End
@@ -61,6 +63,7 @@ Describe Default settings
             Assert NotEmpty(mapcheck('cn', 'n'))
             Assert NotEmpty(mapcheck('cb', 'n'))
             Assert NotEmpty(mapcheck('cB', 'n'))
+            Assert NotEmpty(mapcheck('ca', 'n'))
         End
 
         It does not provide user mappings until hunk is not found
@@ -71,6 +74,7 @@ Describe Default settings
             Assert Falsy(mapcheck('cn', 'n'))
             Assert Falsy(mapcheck('cb', 'n'))
             Assert Falsy(mapcheck('cB', 'n'))
+            Assert Falsy(mapcheck('ca', 'n'))
         End
     End
 End

--- a/test/test_resolve.vimspec
+++ b/test/test_resolve.vimspec
@@ -201,3 +201,20 @@ Describe :ConflictMarkerBoth
         End
     End
 End
+
+Describe :ConflictMarkerCommonAncestors
+    Context applying to diff3
+        Before
+            call s:load(g:lines_diff3)
+        End
+
+        After
+            close!
+        End
+
+        It resolves a conflict by rolling back to common ancestor's
+            ConflictMarkerCommonAncestors
+            Assert Equals(getline(1, '$'), ['ancestors', ''])
+        End
+    End
+End


### PR DESCRIPTION
Sometimes I want to roll back the conflicting part to the common ancestor and use fugitive's [`:Gdiffsplit!`](https://github.com/tpope/vim-fugitive/blob/01f3e0af928857128eec8d998948b80ed1678c18/doc/fugitive.txt#L198) to diff it against ours and theirs. `:ConflictMarkerCommonAncestors` facilitates this workflow.