### PR TITLE
Should change key mappings of `c*`

### DIFF
--- a/plugin/conflict_marker.vim
+++ b/plugin/conflict_marker.vim
@@ -37,13 +37,13 @@ nnoremap <silent><Plug>(conflict-marker-prev-hunk)  :<C-u>ConflictMarkerPrevHunk
 
 function! s:execute_hooks()
     if g:conflict_marker_enable_mappings
-        nmap <buffer>]x <Plug>(conflict-marker-next-hunk)
-        nmap <buffer>[x <Plug>(conflict-marker-prev-hunk)
-        nmap <buffer>ct <Plug>(conflict-marker-themselves)
-        nmap <buffer>co <Plug>(conflict-marker-ourselves)
-        nmap <buffer>cn <Plug>(conflict-marker-none)
-        nmap <buffer>cb <Plug>(conflict-marker-both)
-        nmap <buffer>cB <Plug>(conflict-marker-both-rev)
+        nmap <buffer>]x  <Plug>(conflict-marker-next-hunk)
+        nmap <buffer>[x  <Plug>(conflict-marker-prev-hunk)
+        nmap <buffer>cct <Plug>(conflict-marker-themselves)
+        nmap <buffer>cco <Plug>(conflict-marker-ourselves)
+        nmap <buffer>ccn <Plug>(conflict-marker-none)
+        nmap <buffer>ccb <Plug>(conflict-marker-both)
+        nmap <buffer>ccB <Plug>(conflict-marker-both-rev)
     endif
 
     if exists('g:conflict_marker_hooks') && has_key(g:conflict_marker_hooks, 'on_detected')


### PR DESCRIPTION
It does `nmap` some of `c*` key sequences,
however, there exists `c{motion}` vim key binding.

For example, in the case of below,
it prevents vim default key binding.

```cpp
//   Cursor is here
//   *
some_function_foo_bar();
//   ^^^^^^^^
//   On `ct_`, it had deleted here and started insert mode;
//   however, now `conflict-marker.vim` binds over the key sequence
//   (i.e. `ct`, `@<Plug>(conflict-marker-themselves)`).
```

The key mappings are only for the buffer that is detected conflict.
But once the mappings are activated, they remain until the buffer is wiped out (i.e. `:bw`).

I know there exists `g:conflict_marker_enable_mappings` option to skip the key mapping.
But I think you shouldn't overwrite such commonly used key binding.
